### PR TITLE
First stab at setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ The library is under the 3-clause BSD license, so it may be used for commercial
 purposes. 
 
 
+Installation
+------------
+To install Groundhog in a multi-user setting (such as the LISA lab)
+
+``python setup.py develop --user``
+
+For general installation, simply use
+
+``python setup.py develop``
+
+NOTE: This will install the development version of Theano, if Theano is not
+currently installed.
+
 Neural Machine Translation
 --------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import os
+import setuptools
+
+setuptools.setup(
+    name='groundhog',
+    version='0.1dev',
+    packages=setuptools.find_packages(),
+    description='Recurrent neural net tools built on top of Theano',
+    long_description=open(os.path.join(os.path.dirname(
+        os.path.abspath(__file__)), 'README.md')).read(),
+    license='BSD 3-clause',
+    url='http://github.com/lisa-groundhog/GroundHog/',
+    install_requires=['numpy',
+                      'Theano',],
+    dependency_links=['git+http://github.com/Theano/Theano.git#egg=Theano',],
+    classifiers=['Development Status :: 3 - Alpha',
+                 'Intended Audience :: Science/Research',
+                 'License :: OSI Approved :: BSD License',
+                 'Operating System :: OS Independent',
+                 'Topic :: Scientific/Engineering'],
+)


### PR DESCRIPTION
To run the tutorial, I needed to install the package. I did not see a setup.py so I took a stab at making one. It probably needs to be modified (no email!) but figured I would start the discussion here.

If there is already a setup.py somewhere, this PR can be cancelled.

With this change, I can run the tutorial examples with no other mods (so far).
